### PR TITLE
Remove TODO.unimplemented from AnyKeyedCache

### DIFF
--- a/Sources/Intramodular/Caching/AnyKeyedCache.swift
+++ b/Sources/Intramodular/Caching/AnyKeyedCache.swift
@@ -71,7 +71,7 @@ public struct AnyKeyedCache<Key: Hashable, Value>: KeyedCache {
                 try await cache.removeCachedValue(forKey: .init(stringValue: keyPrefix + $0.stringValue))
             },
             removeAllCachedValues: {
-                TODO.unimplemented
+                try await cache.removeAllCachedValues()
             }
         )
         self.codingCacheImplementation = _AnyCodingKeyedCache(base: cache, keyPrefix: keyPrefix)


### PR DESCRIPTION
I might be missing something here, but it seems that `removeAllCachedValues` is implemented for all classes conforming to `AnyKeyedCache`, so I've removed the TODO.unimplemented statement